### PR TITLE
Use item categories as a fallback to tags

### DIFF
--- a/src/main/java/org/openhab/ui/habot/card/Card.java
+++ b/src/main/java/org/openhab/ui/habot/card/Card.java
@@ -157,7 +157,7 @@ public class Card extends Component implements Identifiable<String> {
     }
 
     /**
-     * Returns whether the card should be ignored during the chat sessions, even if its tags match an @link
+     * Returns whether the card should be ignored during the chat sessions, even if its attributes match an @link
      * {@link Intent}'s extracted entities.
      *
      * @return true if the card is not be considered during chat sessions, false (default) otherwise
@@ -167,7 +167,7 @@ public class Card extends Component implements Identifiable<String> {
     }
 
     /**
-     * Specifies whether the card should be ignored during the chat sessions, even if its tags match an @link
+     * Specifies whether the card should be ignored during the chat sessions, even if its attributes match an @link
      * {@link Intent}'s extracted entities.
      *
      * @param notReuseableInChat true if the card is not be considered during chat sessions, false (default) otherwise

--- a/src/main/java/org/openhab/ui/habot/card/CardBuilder.java
+++ b/src/main/java/org/openhab/ui/habot/card/CardBuilder.java
@@ -316,13 +316,17 @@ public class CardBuilder {
     }
 
     /**
-     * Checks whether a Group item is included in the provided collection and returns it
+     * Tries to find a Group item to act as the card title.
+     * It should contain all other members of the provided collection except itself
      *
-     * @param items
-     * @return the first Group item in the collection
+     * @param items the group of matching items including an eventual GroupItem to find
+     * @return an optional group eligible for the card's title, or null if none was found
      */
     private GroupItem getMatchingGroup(Collection<Item> items) {
-        Optional<Item> groupItem = items.stream().filter(i -> i instanceof GroupItem).findFirst();
+        Optional<Item> groupItem = items.stream().filter(i -> i instanceof GroupItem)
+                .filter(g -> items.stream().allMatch(i -> i.getName().equals(g.getName())
+                        || ((GroupItem) g).getAllMembers().stream().anyMatch(i2 -> i2.getName().contains(i.getName()))))
+                .findFirst();
         return groupItem.isPresent() ? (GroupItem) groupItem.get() : null;
     }
 

--- a/src/main/java/org/openhab/ui/habot/nlp/ItemNamedAttribute.java
+++ b/src/main/java/org/openhab/ui/habot/nlp/ItemNamedAttribute.java
@@ -17,6 +17,7 @@ package org.openhab.ui.habot.nlp;
  */
 public class ItemNamedAttribute {
     public enum AttributeSource {
+        CATEGORY,
         TAG,
         METADATA
     }

--- a/src/main/resources/tagattributes.properties
+++ b/src/main/resources/tagattributes.properties
@@ -8,6 +8,10 @@ door=Door,Doors
 fan=Fan,Fans
 frontdoor=Front door,Frontdoor
 garagedoor=Garage door,Garage doors
+hvac=Heating,AC,Air conditioning
+inverter=Inverter,Inverters,Power Inverter,Power Inverters,Solar Inverter,Solar Inverters
+lawnmower=Lawn mower,Lawn mowers,Mower,Mowers
+lock=Lock,Locks
 lightbulb=Bulb,Bulbs,Lightbulb,Lightbulbs,Light,Lights,Lighting
 motiondetector=Motion,Motion sensor,Motion sensors,Motion detector,Motion sensors
 networkappliance=Network,Server,Servers,Gateway,Gateways,Bridge,Bridges,Router,Routers
@@ -24,8 +28,8 @@ speaker=Speaker,Speakers
 valve=Valve,Valves
 wallswitch=Wall switch,Wall switches
 webservice=Web service,Web Services
-window=Window,Windows
 whitegood=Washing machine,Washing machines,Dishwasher,Dishwashers,Dryer,Dryers,Fridge,Fridges,Oven,Ovens
+window=Window,Windows
 
 # Locations
 cellar=Cellar
@@ -37,17 +41,21 @@ toilet=Toilet,Toilets,WC,WCs
 closet=Closet,Closets
 dressing=Dressing,Dressings,Dressing room,Dressing rooms
 office=Office,Offices
-groundfloor=Ground floor
-firstfloor=First floor
+groundfloor=Ground floor,Downstairs
+firstfloor=First floor,Upstairs
 attic=Attic
 corridor=Corridor,Corridors
 garage=Garage,Garages
+garden=Garden
+terrace=Terrace,Deck
 
 # Properties
 temperature=Temperature,Temperatures
 light=Light,Lights,Lighting
+luminance=Luminance
 humidity=Humidity,Moisture
 presence=Presence
+pressure=Pressure
 smoke=Smoke
 noise=Noise
 rain=Rain
@@ -72,3 +80,36 @@ coalarm=CO alarm,CO alarms,carbon monoxyde alarm,carbon monoxyde alarms
 heating=Heating,Radiator,Radiators,Climate,Thermostat,Thermostats
 cooling=Cooling,Thermostat,Thermostats
 presence=Presence
+
+# Capability
+color=Color
+colortemperature=Color temperature
+volume=Volume
+
+# Additional categories from https://www.eclipse.org/smarthome/documentation/concepts/categories.html
+carbondioxyde=CO2,carbon dioxyde
+soundvolume=Volume,Sound volume
+fire=Fire
+motion=Motion,Movement
+qualityofservice=Wifi level,Signal quality,Quality of service,QoS
+moisture=Humidity,Moisture
+mediacontrol=Media,Music
+colorlight=Bulb,Bulbs,Lightbulb,Lightbulbs,Light,Lights,Lighting
+dimmablelight=Bulb,Bulbs,Lightbulb,Lightbulbs,Light,Lights,Lighting
+
+# Additional icons acting as categories from https://www.eclipse.org/smarthome/documentation/features/ui/iconset/classic/readme.html
+cinemascreen=Screen,Projector screen
+cistern=Cistern
+climate=Climate,Air conditioning
+colorwheel=Color
+dryer=Dryer
+faucet=Faucet
+greenhouse=Greenhouse
+outdoorlight=Outdoor light,Outdoor lights
+pantry=Pantry,Storage room
+pump=Pump
+rgb=Color
+sewerage=Sewerage
+solarplant=Solar panel,Solar panels
+wardrobe=Wardrobe
+washingmachine=Washing machine

--- a/src/main/resources/tagattributes_de.properties
+++ b/src/main/resources/tagattributes_de.properties
@@ -8,10 +8,14 @@ door=Tür,Türen
 fan=Ventilator,Ventilatoren,Lüfter
 frontdoor=Haustür,Haustüren,Eingangstür,Vordertür,Fronttür,Fronttüren
 garagedoor=Garagentor,Garagentore
+hvac=Heizung,Lüftung,Klima,Klimaanlage
+inverter=Wechselrichter
+lawnmower=Rasenmäher,Mähroboter
+lock=Schloss,Schlösser,Türschloss,Türschlossen
 lightbulb=Glühbirne,Glühbirnen,Glühbirne,Glühbirnen,Licht,Lichten,Beleuchtung
 motiondetector=Bewegung,Bewegungssensor,Bewegungssensoren,Bewegungsdetektor,Bewegungssensoren
 networkappliance=Netzwerk,Server,Servers,Gateway,Gateways,Bridge,Bridges,Router
-poweroutlet=Strom,Steckdose,Steckdosen,Steckdose,Steckdosen
+poweroutlet=Strom,Steckdose,Steckdosen
 projector=Projektor,Projektoren,Beamer
 radiatorcontrol=Heizkörper,Heizkörperregelung
 receiver=Receiver,AV-Receiver,Audio-Spieler,Empfänger,Audioempfänger
@@ -24,8 +28,8 @@ speaker=Lautsprecher
 valve=Ventil,Ventile
 wallswitch=Wandschalter,Wanddimmer,Lichtschalter
 webservice=Web Service,Web Services
-window=Fenster
 whitegood=Waschmaschine,Waschmaschinen,Geschirrspüler,Trockner,Wäschetrockner,Kühlschrank,Kühlschränke,Ofen,Bratofen
+window=Fenster
 
 # Locations
 cellar=Keller
@@ -42,12 +46,16 @@ firstfloor=Obergeschoss,OG
 attic=Dachboden
 corridor=Korridor,Korridoren,Wohnungsgang
 garage=Garage,Garagen
+garden=Garten
+terrace=Terrasse,Freisitz
 
 # Properties
 temperature=Temperatur,Temperaturen
 light=Licht,Lichter,Beleuchtung
+luminance=Leuchtdichte
 humidity=Feuchtigkeit
 presence=Anwesenheit,Präsenz
+pressure=Druck
 smoke=Rauch
 noise=Lärm
 rain=Regen
@@ -72,3 +80,36 @@ coalarm=CO-Alarm,CO-Alarme,Kohlenmonoxid-Alarm,Kohlenmonoxyd-Alarme,Kohlenmonoxy
 heating=Heizung,Heizkörper,Klimaanlage,Thermostat,Thermostaten
 cooling=Kühlung,Klimaanlage,Thermostat,Thermostaten
 presence=Anwesenheit,Präsenz
+
+# Capability
+color=Farbe
+colortemperature=Farbtemperatur
+volume=Lautstärke,Tonvolumen
+
+# Additional categories from https://www.eclipse.org/smarthome/documentation/concepts/categories.html
+carbondioxyde=CO2,Kohlendioxid
+soundvolume=Lautstärke,Tonvolumen
+fire=Feuer
+motion=Bewegung
+qualityofservice=Signalkraft,Signalstärke,Dienstgüte
+moisture=Feuchtigkeit
+mediacontrol=Heimunterhaltung,Musik
+colorlight=Glühbirne,Glühbirnen,Glühbirne,Glühbirnen,Licht,Lichten,Beleuchtung
+dimmablelight=Glühbirne,Glühbirnen,Glühbirne,Glühbirnen,Licht,Lichten,Beleuchtung
+
+# Additional icons acting as categories from https://www.eclipse.org/smarthome/documentation/features/ui/iconset/classic/readme.html
+cinemascreen=Bildschirm
+cistern=Wassertank
+climate=Klima
+colorwheel=Farbe
+dryer=Trockner,Wäschetrockner
+faucet=Wasserhahn
+greenhouse=Gewächshaus,Glashaus
+outdoorlight=Außenbeleuchtung,Aussenbeleuchtung
+pantry=Kellerraum,Abstellraum,Speisekammer
+pump=Pumpe
+rgb=Farbe
+sewerage=Abwasser
+solarplant=Solaranlage,Solarmodul,Solarmodulen,Solar-Panel,Solar-Panels
+wardrobe=Schrank,Kleiderschrank
+washingmachine=Waschmaschine

--- a/src/main/resources/tagattributes_fr.properties
+++ b/src/main/resources/tagattributes_fr.properties
@@ -8,6 +8,10 @@ door=porte,portes
 fan=ventilateur,ventilateurs
 frontdoor=porte d'entrée,portes d'entrée
 garagedoor=porte de garage,porte du garage,portes de garage,portes des garages
+hvac=chauffage,air conditionné
+inverter=convertisseur,onduleur,convertisseur solaire,onduleur solaire
+lawnmower=tondeuse,tondeuse à gazon
+lock=serrure,serrures,verrou,verrous
 lightbulb=ampoule,ampoules,lumière,lumières,lampe,lampes
 motiondetector=mouvement,détecteur de mouvement,détecteurs de mouvement,détection de mouvement
 networkappliance=réseau,serveur,serveurs,routeur,routeurs
@@ -24,8 +28,8 @@ speaker=enceinte,enceintes
 valve=valve,valves
 wallswitch=interrupteur,interrupteur,interrupteur mural,interrupteur muraux
 webservice=web service,web services
-window=fenêtre,fenêtres
 whitegood=machine à laver,machines à laver,lave vaiselle,lave vaisselles,sèche linge,sèche linges,réfrigérateur,réfrigérateurs,frigo,frigos,four,fours
+window=fenêtre,fenêtres
 
 # Locations
 cellar=cave
@@ -34,7 +38,7 @@ kitchen=cuisine
 bedroom=chambre,chambre à coucher,chambres,chambres à coucher
 bath=salle de bain,salles de bain
 toilet=toilettes,WC,WCs
-closet=placard,placards
+closet=armoire,armoires,placard,placards
 dressing=dressing,dressings,vestiaire,vestiaires
 office=bureau,bureaux
 groundfloor=rez de chaussée
@@ -42,12 +46,16 @@ firstfloor=premier étage
 attic=grenier
 corridor=couloir,couloirs
 garage=garage,garages
+garden=jardin
+terrace=terrasse
 
 # Properties
 temperature=température,températures
 light=lumière,lumières,lampes,éclairage
+luminance=luminosité
 humidity=humidité
 presence=présence
+pressure=pression
 smoke=fumée
 noise=bruit
 rain=pluie
@@ -69,6 +77,39 @@ firealarm=alarme incendie,alarmes incendie
 leakage=alarme fuite,alarmes fuites
 intrusion=alarme intrusion,alarmes intrusion
 coalarm=alarme CO,alarmes CO,alarme monoxyde de carbone,alarmes monoxyde de carbone
-heating=chauffage,radiateur,radiateurs,thermostat,thermostats,air conditionné
+heating=chauffage,radiateur,radiateurs,thermostat,thermostats
 cooling=air conditionné,thermostat,thermostats
 presence=présence
+
+# Capability
+color=couleur
+colortemperature=température de couleur,température couleur
+volume=volume
+
+# Additional categories from https://www.eclipse.org/smarthome/documentation/concepts/categories.html
+carbondioxyde=CO2,carbon dioxyde
+soundvolume=volume,volume sonore
+fire=incendie
+motion=mouvement
+qualityofservice=signal,signal wifi,qualité de service,QoS
+moisture=humidité
+mediacontrol=média,musique
+colorlight=ampoule,ampoules,lumière,lumières,lampe,lampes
+dimmablelight=ampoule,ampoules,lumière,lumières,lampe,lampes
+
+# Additional icons acting as categories from https://www.eclipse.org/smarthome/documentation/features/ui/iconset/classic/readme.html
+cinemascreen=écran
+cistern=réservoir
+climate=air conditionné,thermostat
+colorwheel=couleur
+dryer=sèche-linge,sèche linge
+faucet=robinet
+greenhouse=serre
+outdoorlight=lumières extérieur,éclairage extérieur
+pantry=garde-manger,débarras
+pump=pompe
+rgb=couleur
+sewerage=eaux usées
+solarplant=panneau solaire,panneaux solaires
+wardrobe=garde-robe,armoire,armoires,placard,placards
+washingmachine=machine à laver,lave linge

--- a/web/src/layouts/designer/CardDesigner.vue
+++ b/web/src/layouts/designer/CardDesigner.vue
@@ -130,7 +130,7 @@
                 </q-chips-input>
               </q-field>
               <q-field label="notReuseableInChat" class="config-field" orientation="vertical"
-                      helper="The card will not be considered when chatting with HABot even if the tags match">
+                      helper="The card will not be considered when chatting with HABot even if the attributes match">
                 <config-bool v-model="selectedNode.component.notReuseableInChat" color="secondary"></config-bool>
               </q-field>
             </div>

--- a/web/src/layouts/itemtable/ItemTable.vue
+++ b/web/src/layouts/itemtable/ItemTable.vue
@@ -42,7 +42,7 @@
         />
       </template>
       <q-td slot="body-cell-attributes" slot-scope="props" :props="props">
-        <q-chip small dense :color="attribute.source === 'TAG' ? 'secondary' : 'tertiary'"
+        <q-chip small dense :color="attribute.source === 'CATEGORY' ? 'primary' : attribute.source === 'TAG' ? 'secondary' : 'tertiary'"
           :style="{ opacity: attribute.inherited ? 0.4 : 1 }"
           v-for="attribute in props.value"
           :key="attribute" class="q-mr-sm">


### PR DESCRIPTION
Add attributes for some additional categories and icons.

Improve detection of groups to use as card titles.

notReusableInChat field documentation.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>